### PR TITLE
fix bad file descriptor

### DIFF
--- a/log/lockfile.go
+++ b/log/lockfile.go
@@ -40,7 +40,7 @@ func newLockFile(p string, noSync bool) (*lockFile, error) {
 		return nil, err
 	}
 
-	lf, err := fileutil.TryLockFile(p, 0, 0600)
+	lf, err := fileutil.TryLockFile(p, os.O_RDWR, 0600)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
running this on linux has given us bad file descriptor.

https://man7.org/linux/man-pages/man2/openat.2.html:
> The argument flags must include one of the following access modes: O_RDONLY,
> O_WRONLY, or O_RDWR.  These request opening the file read-only, write-only,
> or read/write, respectively.

This PR came out of the R&D Hackathon 2022: [project raft-wal](https://github.com/hashicorp/rad-hackathon-march-2022/issues/29). 