### PR TITLE
Onboard to copywrite tooling for license and copyright header compliance

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,11 @@
+schema_version = 1
+
+project {
+  license = "MPL-2.0"
+  copyright_year = 2022
+
+  # (OPTIONAL) A list of globs that should not have copyright/license headers.
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored (e.g., "vendors/**")
+  header_ignore = []
+}


### PR DESCRIPTION
This sets the baseline config for what the `copywrite` tooling needs to add copyright and license headers. Additionally, this also sets the stage for using the `header_ignore` escape hatch if needed.

Once merged, you will be able to run `copywrite headers` or `copywrite license` without any flags, as the tooling will automatically read the SPDX License Identifier and copyright year from this config.

As an aside, copyright headers on config files like this are _not_ required and the tool will skip checking it by default.

Thanks again for being willing to pilot this!