### PR TITLE
Fix logical race caused by read-buffer sharing

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -37,7 +37,8 @@ type Codec interface {
 
 	// Decode a log from the passed byte slice into the log entry pointed to. This
 	// allows the caller to manage allocation and re-use of the bytes and log
-	// entry.
+	// entry. The resulting raft.Log MUST NOT reference data in the input byte
+	// slice since the input byte slice may be re-used for
 	Decode([]byte, *raft.Log) error
 }
 
@@ -148,7 +149,8 @@ func (d *decoder) bytes() []byte {
 		d.err = io.ErrShortBuffer
 		return nil
 	}
-	bs := d.buf[:n]
+	bs := make([]byte, n)
+	copy(bs, d.buf[:n])
 	d.buf = d.buf[n:]
 	return bs
 }

--- a/wal_test.go
+++ b/wal_test.go
@@ -852,6 +852,9 @@ func TestConcurrentReadersAndWriter(t *testing.T) {
 				if log.Index != idx {
 					panic(fmt.Errorf("wrong %s log want=%d got=%d", name, idx, log.Index))
 				}
+				if string(log.Data) != fmt.Sprintf("Log entry %d", log.Index) {
+					panic(fmt.Errorf("wrong data in log %d: %s", log.Index, log.Data))
+				}
 				return 1
 			}
 


### PR DESCRIPTION
E2e testing quickly revealed panics when replicating to real peers. After some pretty confusing debugging, it turned out to be due to a bad/missed assumption when I implemented Read buffer pooling.

Initially the BinaryCodec assumed no pooling of underlying buffers so it just returned the sub-slice of the underlying buffer as the `log.Data`.

When I implemented pooling I implicitly assumed that Codec would always make a copy so it was safe to "free" a read buffer as soon as we are done decoding into the `raft.Log` in `GetLog`.

So if there were concurrent calls to `GetLog` reading different indexes (for example from separate replication go-routines in raft for peers at different indexes), then by the time the replication routine reads the `log.Data` to send to the peer, the slice it points to may have been re-used by a `GetLogs` call at a different index.

In our case one follower ended up replicating large numbers of the same log entry even though every KV write in the test used a random key and value. This actually worked until the size of the correct log entry was small enough that the msgpack encoding of the original was truncated in a way that caused msgpack to error with a short buffer.

This PR fixes the issue by documenting (and testing for BinaryCodec) that codec's MUST NOT return slices of the underlying bytes.

The `TestConcurrentReadersAndWriter` test was modified first to ensure that this issue could be detected and that the WAL implementation does not break it's own assumptions about safe re-use of buffers. The changes to `TestConcurrentReadersAndWriter` fail without the changes to `BinaryCodec` which were completed afterwards. This ensures we are never violating our own assumptions about buffer re-use.

## TODO: Validate performance benefit.

I opted to fix this in the Codec for now and keep read buffer pooling in general, however I'm not sure that makes sense. My reasoning was that our internal buffers are still much larger - 64KiB since that optimizes number of times we need to read from disk when reading larger values. So re-using those while allocating only what we need in the codec may still be beneficial. But it's not really clear to me that that is true - it may well not be much different to just revert all the buffer reuse logic and just start with a smaller min buffer size that is closer to expected final buffer size.

I will consider that option too. That's a bigger PR but leaves the code simpler.
 