### PR TITLE
Use WAL-configured codec when calling newSegment

### DIFF
--- a/wal.go
+++ b/wal.go
@@ -123,7 +123,7 @@ func Open(dir string, opts ...walOpt) (*WAL, error) {
 		// Verify we can decode the entries.
 		// TODO: support multiple decoders to allow rotating codec.
 		if si.Codec != w.codec.ID() {
-			return nil, fmt.Errorf("segment with BasedIndex=%d uses an unknown codec", si.BaseIndex)
+			return nil, fmt.Errorf("segment with BasedIndex=%d uses an unknown codec %d expecting %d", si.BaseIndex, si.Codec, w.codec.ID())
 		}
 
 		// We want to keep this segment since it's still in the metaDB list!
@@ -296,9 +296,9 @@ func (w *WAL) newSegment(ID, baseIndex uint64) types.SegmentInfo {
 		BaseIndex: baseIndex,
 		MinIndex:  baseIndex,
 		SizeLimit: uint32(w.segmentSize),
+		Codec:     w.codec.ID(),
 
 		// TODO make these configurable
-		Codec:      CodecBinaryV1,
 		CreateTime: time.Now(),
 	}
 }


### PR DESCRIPTION
Fixes the TODO in newSegment to create the new segment with the codec currently specified in the WAL options. In addition, log read and expected codec ids when opening a segment and they do not match.

There should be a test for this, I haven't added it yet.