### PR TITLE
Upgrade armon/go-metrics to hashicorp/go-metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.18
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.0
-	github.com/armon/go-metrics v0.4.1
 	github.com/benbjohnson/immutable v0.4.0
 	github.com/benmathews/bench v0.0.0-20210120214102-f7c75b9ef6e7
 	github.com/benmathews/hdrhistogram-writer v0.0.0-20210120211942-3cb1c7c33f95
 	github.com/coreos/etcd v3.3.27+incompatible
 	github.com/google/gofuzz v1.2.0
 	github.com/hashicorp/go-hclog v0.14.1
+	github.com/hashicorp/go-metrics v0.5.0
 	github.com/hashicorp/raft v1.4.0
 	github.com/hashicorp/raft-boltdb v0.0.0-20220329195025-15018e9b97e0
 	github.com/hashicorp/raft-boltdb/v2 v2.2.2
@@ -20,6 +20,7 @@ require (
 )
 
 require (
+	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.0 h1:8exGP7ego3OmkfksihtSouGMZ+hQrhxx+FVELeXpVPE=
 github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-metrics v0.5.0 h1:Hy4VqTCxU5XDWAfgJ2uey0ToDJ4saOS0doXZR0H/JhE=
+github.com/hashicorp/go-metrics v0.5.0/go.mod h1:KEjodfebIOuBYSAe/bHTm+HChmKSxAOXPBieMLYozDE=
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack v1.1.5 h1:9byZdVjKTe5mce63pRVNP1L7UAmdHOTEMGehn6KvJWs=
 github.com/hashicorp/go-msgpack v1.1.5/go.mod h1:gWVc3sv/wbDmR3rQsj1CAktEZzoz1YNK9NfGLXJ69/4=

--- a/metrics/gometrics_collector.go
+++ b/metrics/gometrics_collector.go
@@ -3,7 +3,7 @@
 
 package metrics
 
-import gometrics "github.com/armon/go-metrics"
+import gometrics "github.com/hashicorp/go-metrics"
 
 // GoMetricsCollector implements a Collector that passes through observations to
 // a go-metrics instance. The zero value works, writing metrics to the default

--- a/metrics/gometrics_collector_test.go
+++ b/metrics/gometrics_collector_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	gometrics "github.com/armon/go-metrics"
+	gometrics "github.com/hashicorp/go-metrics"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
This will require bumping to v0.5.0 to signify the breaking change.