### PR TITLE
Add an optional requirement for segment deletability

### DIFF
--- a/options.go
+++ b/options.go
@@ -46,6 +46,12 @@ func WithLogger(logger hclog.Logger) walOpt {
 	}
 }
 
+func WithRequireDeletable() walOpt {
+	return func(w *WAL) {
+		w.requireDeletable = true
+	}
+}
+
 // WithSegmentSize is an option that allows a custom segmentSize to be set.
 func WithSegmentSize(size int) walOpt {
 	return func(w *WAL) {

--- a/types/segment.go
+++ b/types/segment.go
@@ -64,6 +64,9 @@ type SegmentInfo struct {
 	// limit in the sense that the final Append usually takes the segment file
 	// past this size before it is considered full and sealed.
 	SizeLimit uint32
+
+	// DeletableTime records when a sealed segment was marked as deletable.
+	DeletableTime time.Time
 }
 
 // SegmentFiler is the interface that provides access to segments to the WAL. It


### PR DESCRIPTION
When the option is enabled, attempts to delete will block until all impacted segments are marked deletable.