### PR TITLE
Add CODEOWNERS file in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Default owner
-* @hashicorp/team-ip-compliance
+* @hashicorp/team-ip-compliance @hashicorp/consul-core-reviewers @hashicorp/raft-force
 
 # Add override rules below. Each line is a file/folder pattern followed by one or more owners.
 # Being an owner means those groups or individuals will be added as reviewers to PRs affecting

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,13 @@
-# Copyright (c) HashiCorp, Inc.
+# Each line is a file pattern followed by one or more owners.
+# More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @consul-core-reviewers @raft-force
+# Default owner
+* @hashicorp/team-ip-compliance
+
+# Add override rules below. Each line is a file/folder pattern followed by one or more owners.
+# Being an owner means those groups or individuals will be added as reviewers to PRs affecting
+# those areas of the code.
+# Examples:
+# /docs/  @docs-team
+# *.js    @js-team
+# *.go    @go-team


### PR DESCRIPTION
Add CODEOWNERS file to define code ownership rules.

This PR adds a CODEOWNERS file in `CODEOWNERS` to help manage code review assignments and maintain clear ownership of different parts of the codebase.