### PR TITLE
Use two step PR approval process for IP Compliance team members

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -75,7 +75,7 @@ jobs:
 
       # Save coverage report parts
       - name: Upload and save artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: Test Results
           path: ${{ env.TEST_RESULTS }}

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.19 ]
+        go-version: [ 1.22 ]
 
     steps:
       - name: Setup go

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -32,7 +32,7 @@ jobs:
         run: go mod download
 
       - name: Cache / restore go modules
-        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/two-step-pr-approval.yml
+++ b/.github/workflows/two-step-pr-approval.yml
@@ -1,0 +1,20 @@
+name: Two-Stage PR Review Process
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review, converted_to_draft]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  manage-pr-status:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Two stage PR review
+        uses: hashicorp/two-stage-pr-approval@v0.1.0


### PR DESCRIPTION
We have been instating this process to ensure that any PRs raised by IP compliance team members follows a comprehensive internal team review first and then become open for wider review for shared/core libraries that we co-own.
Memo for this change : https://go.hashi.co/memo/eng-001